### PR TITLE
[VGNWB-281] Add Citesphere authorization page

### DIFF
--- a/src/components/auth/CitesphereAuth.vue
+++ b/src/components/auth/CitesphereAuth.vue
@@ -2,10 +2,10 @@
 	v-row(align="center" justify="center")
 		v-col(cols="6")
 			v-card
-				v-form(ref="loginForm" v-model="valid")
-					v-card-title#title Github Authorization
+				v-form(ref="citesphereAuth" v-model="valid")
+					v-card-title#title Citesphere Authorization
 					v-card-text
-						a(href=`https://github.com/login/oauth/authorize?scope=user&client_id=${process.env.VUE_APP_GITHUB_CLIENT_ID}`) authorize
+						a(href=`https://diging-dev.asu.edu/citesphere-review/api/v1/oauth/authorize?scope=read&client_id=${process.env.VUE_APP_CITESPHERE_CLIENT_ID}&response_type=code&state=vogon`) authorize
 					v-card-actions
 
 </template>
@@ -14,9 +14,9 @@
 import { VForm } from '@/interfaces/GlobalTypes';
 import { Component, Vue } from 'vue-property-decorator';
 @Component({
-  name: 'GithubForm',
+  name: 'CitesphereAuth',
 })
-export default class GithubForm extends Vue {
+export default class CitesphereAuth extends Vue {
   private password: string = '';
   private username: string = '';
   private error: boolean = false;
@@ -29,33 +29,21 @@ export default class GithubForm extends Vue {
   }
 
   /**
-   * get access code from github after getting auth code from github
-   * @param {String} code - Github authorization code from querystring.
+   * get access code from citesphere after getting auth code from citesphere
+   * @param {String} code - Citesphere authorization code from querystring.
    */
   public getAccessToken(code: string | Array<string | null>) {
-	Vue.$axios
-		.get('github-token/', {
+	Vue.$axios.get('citesphere-token/', {
 		params: {
-			code,
+		code,
 		},
-		})
+	})
 		.then((result) => {
-			this.$router.push('dashboard');
+		this.$router.push('/dashboard');
 		})
 		.catch((error) => {
-		// TODO: deal with errors
 		this.error = true;
 		});
   }
 }
 </script>
-
-<style scoped>
-.project-item {
-  padding: 0;
-  margin: 10px 0;
-}
-#title {
-  background: grey;
-}
-</style>

--- a/src/components/auth/CitesphereAuth.vue
+++ b/src/components/auth/CitesphereAuth.vue
@@ -6,6 +6,7 @@
 					v-card-title#title Citesphere Authorization
 					v-card-text
 						a(href=`https://diging-dev.asu.edu/citesphere-review/api/v1/oauth/authorize?scope=read&client_id=${process.env.VUE_APP_CITESPHERE_CLIENT_ID}&response_type=code&state=vogon`) authorize
+						v-alert(v-if="error" type="error" dense dismissible class="my-4") {{ errorMsg }}
 					v-card-actions
 
 </template>
@@ -20,12 +21,19 @@ export default class CitesphereAuth extends Vue {
   private password: string = '';
   private username: string = '';
   private error: boolean = false;
+  private errorMsg: string = '';
   private valid: boolean = false;
 
 	public created() {
 		if (this.$route.query.code) {
 			this.getAccessToken(this.$route.query.code);
-		}
+	}
+  if (this.$route.query.error) {
+		const errorCode = this.$route.query.error;
+		const errorDescription = this.$route.query.error_description;
+		this.error = true;
+		this.errorMsg = `Error while authorizing User - Code: ${errorCode}, Description: ${errorDescription}`;
+	}
   }
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 
+import CitesphereAuthView from './views/auth/CitesphereAuthView.vue';
 import ForgotPasswordView from './views/auth/ForgotPasswordView.vue';
 import GithubView from './views/auth/GithubView.vue';
 import LoginView from './views/auth/LoginView.vue';
@@ -167,6 +168,11 @@ export default new Router({
 			path: '/github',
 			name: 'github',
 			component: GithubView,
+		},
+		{
+			path: '/auth/citesphere',
+			name: 'citesphere-auth',
+			component: CitesphereAuthView,
 		},
 		{
 			path: '/annotate/:id',

--- a/src/views/auth/CitesphereAuthView.vue
+++ b/src/views/auth/CitesphereAuthView.vue
@@ -1,0 +1,20 @@
+
+<template lang="pug">
+	CitesphereAuth
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+import CitesphereAuth from '@/components/auth/CitesphereAuth.vue';
+
+@Component({
+  name: 'CitesphereAuthView',
+  components: {
+	  CitesphereAuth,
+  },
+})
+class CitesphereAuthView extends Vue {}
+
+export default CitesphereAuthView;
+</script>


### PR DESCRIPTION
**Authorization Flow**

* Add endpoint `/auth/citesphere` - performs OAuth via CItesphere, redirects back to the same URL with authorization code.
* Citesphere redirects to `/auth/citesphere?code=<code>`, the `code` is sent to backend
* Backend uses the code to generate access token
* User is redirected back to `/dashboard`